### PR TITLE
Update Seasides Conference dates to Feb 19-21, 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
         <canvas class="particles" id="particles"></canvas>
         <div class="content">
             <h1 class="hero-title glitch" data-text="H4RDW4R3 H4CK1NG VI77AG3">HARDWARE HACKING VILLAGE</h1>
-            <p style="font-size: 1rem; margin-bottom: 2rem; color: #808080;">Seasides Conference, International Center Goa | 20 - 22 Feb 2025</p>
+            <p style="font-size: 1rem; margin-bottom: 2rem; color: #808080;">Seasides Conference, International Center Goa | 19 - 21 Feb 2026</p>
             <div class="spacer"></div>         
             <div class="countdown-timer">
                 <div class="timer-item">
@@ -94,9 +94,9 @@
                     <img src="/static/media/img/news.jpeg" alt="Event Banner" class="event-image">
                 </div>
                 <div class="event-details">
-                    <h2 class="event-title" data-text="BADGE_QUEST_2025">BADGE QUEST 2025</h2>
+                    <h2 class="event-title" data-text="BADGE_QUEST_2026">BADGE QUEST 2026</h2>
                     <div class="event-info" style="align-self: center; align-items: center;">
-                        <p><span class="highlight">📅 DATE:</span> 20-22 FEB 2025</p>
+                        <p><span class="highlight">📅 DATE:</span> 19-21 FEB 2026</p>
                         <p><span class="highlight">⏰ TIME:</span> 11:00 IST </p>
                         <p><span class="highlight">📍 LOCATION:</span> HARDWARE HACKING VILLAGE</p>
                         <div class="spacer"></div>
@@ -216,9 +216,9 @@
             <span class="modal-close">&times;</span>
             <img src="/static/media/img/news.jpeg" alt="Event Banner" class="modal-banner">
             <div class="modal-text">
-                <p>Join us at the Hardware Hacking Village on <strong>2025-02-20 at 11:00 IST</strong> for 
+                <p>Join us at the Hardware Hacking Village on <strong>2026-02-19 at 11:00 IST</strong> for 
                 <span class="highlight">Badge Quest</span>, a unique event that blends the excitement of a CTF challenge 
-                with a classic scavenger hunt—hosted during Seasides 2025 (2025-02-20 to 2025-02-22).</p>
+                with a classic scavenger hunt—hosted during Seasides 2026 (2026-02-19 to 2026-02-21).</p>
                 <a href="https://hexguard.net/" class="cta-button" target="_blank">Register Now</a>
             </div>
         </div>
@@ -253,7 +253,7 @@
     
     <footer class="site-footer">
         <div class="footer-content">
-            <p>&copy; 2024 Hardware Hacking Village. All rights reserved. [Except The Music] | Best viewed on large screen</p>
+            <p>&copy; <span id="current-year"></span> Hardware Hacking Village. All rights reserved. [Except The Music] | Best viewed on large screen</p>
         </div>
     </footer>
     <script src="/static/js/musicPlayer.js"></script>

--- a/schedule.html
+++ b/schedule.html
@@ -67,15 +67,15 @@
             <div class="spacer"></div>
             <div class="schedule-container">
                 <div class="day-column">
-                    <h2>Day 1 - 20 Feb 2025</h2>
+                    <h2>Day 1 - 19 Feb 2026</h2>
                     <div class="event-list" id="day1-events"></div>
                 </div>
                 <div class="day-column">
-                    <h2>Day 2 - 21 Feb 2025</h2>
+                    <h2>Day 2 - 20 Feb 2026</h2>
                     <div class="event-list" id="day2-events"></div>
                 </div>
                 <div class="day-column">
-                    <h2>Day 3 - 22 Feb 2025</h2>
+                    <h2>Day 3 - 21 Feb 2026</h2>
                     <div class="event-list" id="day3-events"></div>
                 </div>
             </div>
@@ -121,7 +121,7 @@
 
     <footer class="site-footer">
         <div class="footer-content">
-            <p>&copy; 2024 Hardware Hacking Village. All rights reserved. [Except The Music]</p>
+            <p>&copy; <span id="current-year"></span> Hardware Hacking Village. All rights reserved. [Except The Music]</p>
         </div>
     </footer>
 

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -405,7 +405,7 @@ window.dataLayer = window.dataLayer || [];
 
 
 // Countdown Timer
-const eventDate = new Date("February 20, 2025 09:30:00").getTime();
+const eventDate = new Date("February 19, 2026 09:30:00").getTime();
 
 function updateCountdown() {
     const now = new Date().getTime();
@@ -452,6 +452,12 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeModal();
     initializeParticles();
     updateCountdown();
+    
+    // Set current year in footer
+    const yearElement = document.getElementById('current-year');
+    if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+    }
 });
 
 if (document.readyState === 'complete') {
@@ -459,11 +465,17 @@ if (document.readyState === 'complete') {
     initializeModal();
     initializeParticles();
     updateCountdown();
+    
+    // Set current year in footer
+    const yearElement = document.getElementById('current-year');
+    if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+    }
 }
 
 const shareContent = {
     title: "Hardware Hacking Village at Seasides Conference",
-    description: "Join us for an exciting Hardware Hacking Village at Seasides Conference, featuring Flipper Zero, Badge Making, HAM Radio, and more! February 20-22, 2025 at International Center Goa.",
+    description: "Join us for an exciting Hardware Hacking Village at Seasides Conference, featuring Flipper Zero, Badge Making, HAM Radio, and more! February 19-21, 2026 at International Center Goa.",
     url: window.location.href
 };
 


### PR DESCRIPTION
## Changes

This PR updates the Seasides Conference dates from Feb 20-22, 2025 to Feb 19-21, 2026.

### Updates Made:
- ✅ Updated main conference date display on homepage
- ✅ Updated Badge Quest 2025 → Badge Quest 2026 with new dates
- ✅ Updated all 3 schedule day headers (Day 1-3)
- ✅ Updated countdown timer to Feb 19, 2026
- ✅ Updated social sharing descriptions
- ✅ Made footer year dynamic to automatically show current year

### Files Modified:
- `index.html` - Main page date references
- `schedule.html` - Schedule day headers
- `static/js/scripts.js` - Countdown timer, sharing content, and dynamic footer year

All dates have been consistently updated across the site to reflect the new 2026 conference dates.